### PR TITLE
Adds apt-get update in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
 
       - name: Setup System
         run: |
+          sudo apt-get update
           sudo apt-get install libsqlite3-dev
-          
+
       - name: Set up Ruby
         uses: actions/setup-ruby@v1
         with:


### PR DESCRIPTION
CI workflow has the error which it needs apt-get update.
https://github.com/two-pack/redmine_auto_assign_group/commit/e5949a3152df7215c06d0b2b183b5af4bb1cf097/checks?check_suite_id=342437019