### PR TITLE
Matches chrome version on CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,6 @@ jobs:
 
       - name: Set up chromedriver
         uses: nanasess/setup-chromedriver@master
-        with:
-          chromedriver-version: '79.0.3945.36'
 
       - name: Check Versions
         run: |


### PR DESCRIPTION
Broken CI because chromedriver's version doesn't match google-chrome.
https://github.com/two-pack/redmine_auto_assign_group/commit/0c5e4fdc26884e6bba0906e83552324d15d95e0b/checks?check_suite_id=396596814

This request remove version specified from nanasess/setup-chromedriver action.