### PR TITLE
Fixes invalid assertion to visit page

### DIFF
--- a/test/integration/groups_rules_tab_test.rb
+++ b/test/integration/groups_rules_tab_test.rb
@@ -12,7 +12,7 @@ module RedmineAutoAssignGroup
     def open_rules_tab(group_number)
       Retryable.retryable(tries: 10) do
         visit '/groups/' + group_number.to_s + '/edit'
-        assert_not_nil page
+        assert_visit
         find('a#tab-rules').click
       end
     end
@@ -21,7 +21,7 @@ module RedmineAutoAssignGroup
       login_with_admin
 
       visit '/groups'
-      assert_not_nil page
+      assert_visit
     end
 
     def teardown

--- a/test/integration/plugins_page_test.rb
+++ b/test/integration/plugins_page_test.rb
@@ -12,7 +12,7 @@ module RedmineAutoAssignGroup
       login_with_admin
 
       visit '/admin/plugins'
-      assert_not_nil page
+      assert_visit
     end
 
     def teardown

--- a/test/integration/users_test.rb
+++ b/test/integration/users_test.rb
@@ -19,7 +19,7 @@ module RedmineAutoAssignGroup
 
     def create_user_and_display_groups_tab(firstname, lastname, email)
       visit '/users'
-      assert_not_nil page
+      assert_visit
 
       click_link('New user')
       fill_in 'Login', with: @created_user_login
@@ -35,7 +35,7 @@ module RedmineAutoAssignGroup
 
     def delete_user
       visit '/users'
-      assert_not_nil page
+      assert_visit
       click_link(@created_user_login)
       page.accept_confirm 'Are you sure?' do
         click_link('Delete')
@@ -174,7 +174,7 @@ module RedmineAutoAssignGroup
 
     def test_do_not_assign_group_when_user_is_editted
       visit '/users'
-      assert_not_nil page
+      assert_visit
 
       click_link('jsmith')
       fill_in 'First name', with: 'James'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,5 +70,9 @@ module RedmineAutoAssignGroup
     def finished_all_ajax_requests?
       page.evaluate_script('jQuery.active').zero?
     end
+
+    def assert_visit
+      assert has_selector?("div#content")
+    end
   end
 end


### PR DESCRIPTION
**assert_not_nil page** through rails error page.
This PR fixes it which check also to exist div#content.

But this plugin has no failure test cases with this problem.
See: https://github.com/two-pack/redmine_xlsx_format_issue_exporter/pull/89