### PR TITLE
adapt user_patch.rb to reflect activerecord-6.x save() definition

### DIFF
--- a/lib/redmine_auto_assign_group/user_patch.rb
+++ b/lib/redmine_auto_assign_group/user_patch.rb
@@ -1,6 +1,6 @@
 module RedmineAutoAssignGroup
   module UserPatch
-    def save(*args, &block)
+    def save(**options, &block)
       return super unless new_record?
 
       new_user = super


### PR DESCRIPTION
Fixes #34 
```ArgumentError: wrong number of arguments (given 1, expected 0) /var/lib/gems/3.0.0/gems/activerecord-6.1.7.2/lib/active_record/suppressor.rb:43:in `save' /var/www/redmine/plugins/redmine_auto_assign_group/lib/redmine_auto_assign_group/user_patch.rb:4:in `save' /var/lib/gems/3.0.0/gems/activerecord-6.1.7.2/lib/active_record/persistence.rb:617:in `update_attribute'```